### PR TITLE
Edited comments and readme

### DIFF
--- a/README
+++ b/README
@@ -1,18 +1,19 @@
 Emphasis
 ========
 
-Emphasis provides dynamic paragraph-specific anchor links and the ability to highlight text in a document,
-all of which is made available in the URL hash so it can be emailed, bookmarked, or shared.
+Emphasis provides dynamic paragraph-specific anchor links and the 
+ability to highlight text in a document, all of which is made available 
+in the URL hash so it can be emailed, bookmarked, or shared. 
 
-For more information and examples please go to this blog post:
-
-http://open.blogs.nytimes.com/2011/01/11/emphasis-update-and-source/
+For more information and examples please go to this blog post: 
+http://open.blogs.nytimes.com/2011/01/11/emphasis-update-and-source/ 
 
 Configuration
 -------------
 
-The main configuration element si specifiying what paragraph elements are in scope and are not. To this end
-we specify the elements on or near Line 54:
+The main configuration element is specifiying what paragraph elements 
+are in scope and which are not. To this end we specify the elements on 
+or near Line 54: 
 
     this.paraSelctors = $$(
                         ".entry p:not(p[class]):not(:empty)",
@@ -20,9 +21,11 @@ we specify the elements on or near Line 54:
                         "article p:not(p[class]):not(:empty)"
                         );
 
-This covers a lot of common markup in many sites and blog. However this could be configured for your specific site.
+This covers a lot of common markup in many sites and blog. However this
+could be configured for your specific site.
 
-Example: If all you P tags reside in DIV tags with the "entry" classname, then this would be sufficient:
+Example: If all your P tags reside in DIV tags with the "entry"
+classname, then this would be sufficient:
 
     this.paraSelctors = $$(".entry p:not(p[class]):not(:empty)");
 
@@ -32,15 +35,14 @@ Over at The New York Times, we use the following:
 
 Dependencies
 ------------
-Currently this requires that you use the PrototypeJS library - tested with version 1.6.
-
-http://prototypejs.org/download
+Currently this requires that you use the PrototypeJS library
+(http://prototypejs.org/download) - tested with version 1.6.
 
 Thanks
 ------
 
-Levenshtein calculation in the script is based on some nice code by Andrew Hedges
-http://andrew.hedges.name/experiments/levenshtein/
+Levenshtein calculation in the script is based on some nice code by
+Andrew Hedges (http://andrew.hedges.name/experiments/levenshtein/)
 
 To-Do
 -----

--- a/js/emphasis-src.js
+++ b/js/emphasis-src.js
@@ -50,8 +50,8 @@ var Emphasis = {
     config: function() {
     /*
         Eligible Paragraphs
-        This uses some common markup for plain and simpel paragraphs - those that are not empty, no classes.
-        We use PrototypeJS for its css selector awesomeness, but your needs might be simpler (getElementsByTagName('p') etc.)
+        This uses some common markup for plain and simple paragraphs - those that are not empty, no classes.
+        We use PrototypeJS for its CSS selector awesomeness, but your needs might be simpler (getElementsByTagName('p') etc.)
     */
         this.paraSelctors      = $$(".entry p:not(p[class]):not(:empty)", ".post p:not(p[class]):not(:empty)", "article p:not(p[class]):not(:empty)");
 
@@ -150,7 +150,7 @@ var Emphasis = {
     },
 
     paragraphList: function() {
-    /*  Build a list of Paragrphs, keys, and add meta-data to each Paragraph in DOM, saves list for later re-use */
+    /*  Build a list of Paragraphs, keys, and add meta-data to each Paragraph in DOM, saves list for later re-use */
         if (this.pl) return this.pl;
         var instance = this;
         var list = [];
@@ -166,7 +166,7 @@ var Emphasis = {
                 keys.push(k);
                 pr.setAttribute("data-key", k); // Unique Key
                 pr.setAttribute("data-num", c); // Order
-                Event.observe(pr, 'click', function(e) { instance.paragraphClick(e); }); // Prefer not doing this for each Paragraph but seemes nesesary
+                Event.observe(pr, 'click', function(e) { instance.paragraphClick(e); }); // Prefer not doing this for each Paragraph but seems necessary
                 c++;
             }
         }
@@ -176,7 +176,7 @@ var Emphasis = {
     },
 
     paragraphClick: function(e) {
-    /*  Clicking a Paragrsph has consequences for Highlighting, selecting and changing active Anchor */
+    /*  Clicking a Paragraph has consequences for Highlighting, selecting and changing active Anchor */
         if (!this.vu) { return; }
 
         var hasChanged = false;
@@ -371,7 +371,7 @@ var Emphasis = {
             var para = this.paragraphList().list[h[i]-1] || false;
             if (para) {
                 var sntns = s[h[i].toString()] || false;
-                var multi = !sntns || sntns.length==0; // Individual sentences, or whole paragraphy?
+                var multi = !sntns || sntns.length==0; // Individual sentences, or whole paragraph?
                 var lines = this.getSentences(para);
                 var jLen  = lines.length;
 


### PR DESCRIPTION
When I was looking through the source code, and reading the readme file, some mistakes got on my nerves. Being the pedant that I am, I figured I'd fork the code and correct those mistakes.

So here it is: corrected and spell-checked. I also rewrapped the readme to 72-character lines, just for fun.

Maybe later I'll dig into the code and work on the "remove framework dependency" todo. :-)
